### PR TITLE
Add ability to pass in lowercase postcodes

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,7 +52,7 @@ def get_tasks(postcode, street_paon_saon):
                          'respective parts. Expected street_PAON_SAON.')
 
     query_dict = {
-        'postcode': postcode,
+        'postcode': postcode.upper(),
         'street': parts[0],
         'paon': parts[1],
     }


### PR DESCRIPTION
Add code to convert the postcode into uppercase.  This is due to the requirements of the PPI API.
